### PR TITLE
Renaming and refactoring

### DIFF
--- a/balderdash/__init__.py
+++ b/balderdash/__init__.py
@@ -7,7 +7,7 @@ from typing import Iterable, Iterator, Optional
 
 from .parser import generate_designs, generate_flowers
 from .types import Bouquet, Design, Flower, FlowerCounter
-from .utils import bouquet_to_string, design_complexity, flower_demand, read_inputs
+from .utils import bouquet_to_string, design_complexity, flower_demand, read_lines
 
 __version__ = "0"  # Forever at nil
 
@@ -74,8 +74,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    designs = list(generate_designs(read_inputs(args.infile)))
+    designs = list(generate_designs(read_lines(args.infile)))
     designs.sort(key=design_complexity, reverse=True)
-    flowers = generate_flowers(read_inputs(args.infile))
+    flowers = generate_flowers(read_lines(args.infile))
     for bouquet in generate_bouquets(flowers, designs, buffer=args.buffer):
         print(bouquet_to_string(bouquet))

--- a/balderdash/__init__.py
+++ b/balderdash/__init__.py
@@ -5,7 +5,7 @@ from collections import Counter
 from itertools import islice
 from typing import Iterable, Iterator, Optional
 
-from .parser import generate_designs, generate_flowers
+from .parser import design_generator, flower_generator
 from .types import Bouquet, Design, Flower, FlowerCounter
 from .utils import bouquet_to_string, design_complexity, flower_demand, read_lines
 
@@ -74,8 +74,8 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    designs = list(generate_designs(read_lines(args.infile)))
+    designs = list(design_generator(read_lines(args.infile)))
     designs.sort(key=design_complexity, reverse=True)
-    flowers = generate_flowers(read_lines(args.infile))
+    flowers = flower_generator(read_lines(args.infile))
     for bouquet in generate_bouquets(flowers, designs, buffer=args.buffer):
         print(bouquet_to_string(bouquet))

--- a/balderdash/parser.py
+++ b/balderdash/parser.py
@@ -34,16 +34,16 @@ def create_flower(parser: Lark, flower: str) -> Flower:
     return Flower(*map(str, tree.children))
 
 
-def generate_flowers(flowers: Iterable[str]) -> Iterator[Flower]:
-    """Yields parsed Flowers from an iterable of flower specifications."""
-    parser = get_parser("flower")
-    return map(partial(create_flower, parser), flowers)
-
-
-def generate_designs(designs: Iterable[str]) -> Iterator[Design]:
+def design_generator(designs: Iterable[str]) -> Iterator[Design]:
     """Yields parsed Designs from an iterable of design specifications."""
     parser = get_parser("design")
     return map(partial(create_design, parser), designs)
+
+
+def flower_generator(flowers: Iterable[str]) -> Iterator[Flower]:
+    """Yields parsed Flowers from an iterable of flower specifications."""
+    parser = get_parser("flower")
+    return map(partial(create_flower, parser), flowers)
 
 
 def get_parser(start: str) -> Lark:

--- a/balderdash/utils.py
+++ b/balderdash/utils.py
@@ -8,8 +8,8 @@ from .types import Bouquet, Design, FlowerCounter
 def bouquet_to_string(bouquet: Bouquet) -> str:
     """Returns a string representation of the given Bouquet."""
     flowers = sorted(bouquet.flowers.items())
-    flowers_formatted = (f"{count}{flower.species}" for flower, count in flowers)
-    return f"{bouquet.name}{bouquet.size}{''.join(flowers_formatted)}"
+    flower_quantities = (f"{count}{flower.species}" for flower, count in flowers)
+    return "".join(chain(bouquet.name, bouquet.size, flower_quantities))
 
 
 def design_complexity(design: Design) -> int:

--- a/balderdash/utils.py
+++ b/balderdash/utils.py
@@ -25,7 +25,7 @@ def flower_demand(designs: Iterable[Design]) -> FlowerCounter:
     return Counter(chain.from_iterable(elements))
 
 
-def read_inputs(fp: TextIO) -> Iterator[str]:
+def read_lines(fp: TextIO) -> Iterator[str]:
     """Yields lines from the given filepointer until an empty line is hit."""
     while line := fp.readline().strip():
         yield line

--- a/tests/test_bouquet_generator.py
+++ b/tests/test_bouquet_generator.py
@@ -3,14 +3,14 @@ from itertools import zip_longest
 import pytest
 
 from balderdash import generate_bouquets
-from balderdash.parser import generate_designs, generate_flowers
+from balderdash.parser import design_generator, flower_generator
 
 
 @pytest.fixture
 def designs():
     """Return a list of designs, ordered by complexity."""
     designs = "AL1a1b4", "BL2a2", "CL1a2", "XL1", "YS1"
-    return list(generate_designs(designs))
+    return list(design_generator(designs))
 
 
 @pytest.mark.parametrize(
@@ -26,7 +26,7 @@ def designs():
     ],
 )
 def test_basic_creation(designs, flowers, expected_names):
-    flowers = generate_flowers(flowers)
+    flowers = flower_generator(flowers)
     bouquets = generate_bouquets(flowers, designs)
     for bouquet, expected_name in zip_longest(bouquets, expected_names):
         assert bouquet.name == expected_name
@@ -40,7 +40,7 @@ def test_basic_creation(designs, flowers, expected_names):
     ],
 )
 def test_buffering_in_creation(designs, flowers, buffer_size, expected_names):
-    flowers = generate_flowers(flowers)
+    flowers = flower_generator(flowers)
     bouquets = generate_bouquets(flowers, designs, buffer=buffer_size)
     for bouquet, expected_name in zip_longest(bouquets, expected_names):
         assert bouquet.name == expected_name
@@ -56,8 +56,8 @@ def test_buffering_in_creation(designs, flowers, buffer_size, expected_names):
     ],
 )
 def test_buffer_refilling(buffer_size, expected_names):
-    designs = list(generate_designs(["DL5", "CL4", "BL2", "AL1"]))
-    flowers = generate_flowers(["aL"] * 10)
+    designs = list(design_generator(["DL5", "CL4", "BL2", "AL1"]))
+    flowers = flower_generator(["aL"] * 10)
     bouquets = generate_bouquets(flowers, designs, buffer=buffer_size)
     for bouquet, expected_name in zip_longest(bouquets, expected_names):
         assert bouquet.name == expected_name
@@ -72,16 +72,16 @@ def test_buffer_refilling(buffer_size, expected_names):
     ],
 )
 def test_buffer_growth(buffer_size, expected_names):
-    designs = list(generate_designs(["DL5", "CL4"]))
-    flowers = generate_flowers(["aL"] * 10)
+    designs = list(design_generator(["DL5", "CL4"]))
+    flowers = flower_generator(["aL"] * 10)
     bouquets = generate_bouquets(flowers, designs, buffer=buffer_size)
     for bouquet, expected_name in zip_longest(bouquets, expected_names):
         assert bouquet.name == expected_name
 
 
 def test_create_from_buffer_remainder():
-    designs = list(generate_designs(["AL3", "BL1"]))
-    flowers = generate_flowers(["aL"] * 5)
+    designs = list(design_generator(["AL3", "BL1"]))
+    flowers = flower_generator(["aL"] * 5)
     bouquets = generate_bouquets(flowers, designs, buffer=100)
     for bouquet, expected_name in zip_longest(bouquets, "ABB"):
         assert bouquet.name == expected_name

--- a/tests/test_design_parser.py
+++ b/tests/test_design_parser.py
@@ -3,7 +3,7 @@ from string import ascii_uppercase
 
 import pytest
 
-from balderdash.parser import generate_designs
+from balderdash.parser import design_generator
 from balderdash.types import Design
 
 
@@ -71,9 +71,9 @@ def test_create_design_required_flowers_not_alphabetized(design_parser):
         design_parser("AL2b2a5")
 
 
-def test_generate_designs():
+def test_design_generator():
     patterns = ["AL1a5", "BS2x2y5"]
-    designs = list(generate_designs(patterns))
+    designs = list(design_generator(patterns))
     for design, pattern in zip_longest(designs, patterns):
         assert isinstance(design, Design)
         assert design.name == pattern[0]

--- a/tests/test_flower_parser.py
+++ b/tests/test_flower_parser.py
@@ -3,7 +3,7 @@ from string import ascii_lowercase
 
 import pytest
 
-from balderdash.parser import generate_flowers
+from balderdash.parser import flower_generator
 from balderdash.types import Flower
 
 
@@ -30,9 +30,9 @@ def test_create_flower_bad_syntax(flower_parser, pattern):
         flower_parser(pattern)
 
 
-def test_generate_flowers():
+def test_flower_generator():
     patterns = ["".join(flower) for flower in product(ascii_lowercase, "SL")]
-    flowers = list(generate_flowers(patterns))
+    flowers = list(flower_generator(patterns))
     for flower, (species, size) in zip_longest(flowers, patterns):
         assert isinstance(flower, Flower)
         assert flower.species == species

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,7 @@ from balderdash.utils import (
     bouquet_to_string,
     design_complexity,
     flower_demand,
-    read_inputs,
+    read_lines,
 )
 
 
@@ -88,5 +88,5 @@ def test_flower_demand(design_strings, counts):
         pytest.param("one\n\nnew-block", ["one"], id="empty line separates block"),
     ],
 )
-def test_read_inputs(input, expected):
-    assert list(read_inputs(StringIO(input))) == expected
+def test_read_lines(input, expected):
+    assert list(read_lines(StringIO(input))) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@ from string import ascii_uppercase
 
 import pytest
 
-from balderdash import generate_designs
+from balderdash import design_generator
 from balderdash.types import Bouquet, Flower
 from balderdash.utils import (
     bouquet_to_string,
@@ -51,7 +51,7 @@ def test_bouquet_string_flower_specification(flowers, expected):
     ],
 )
 def test_design_complexity_comparison(design_strings, expected_name):
-    designs = list(generate_designs(design_strings))
+    designs = list(design_generator(design_strings))
     ordered = sorted(designs, key=design_complexity)
     for design, expected_name in zip(ordered, expected_name):
         assert design.name == expected_name
@@ -74,7 +74,7 @@ def test_design_complexity_comparison(design_strings, expected_name):
     ],
 )
 def test_flower_demand(design_strings, counts):
-    designs = list(generate_designs(design_strings))
+    designs = list(design_generator(design_strings))
     expected_counts = {Flower(*flower): count for flower, count in counts.items()}
     assert flower_demand(designs) == expected_counts
 


### PR DESCRIPTION
Renames a number of parsing/utility functions for clarity

* Renames `generate_designs` to `design_generator`;
* Renames `generate_flowers` to `flower_generator`;
* Renames `read_inputs` to `read_lines`;
* Refactors `bouquet_to_string` to use one string formatting step less.